### PR TITLE
[MVP Feature] Implement map modes toggle between Live and Explore Mode

### DIFF
--- a/Muzik/src/App.css
+++ b/Muzik/src/App.css
@@ -65,7 +65,7 @@ input[type="text"] {
   width: 40rem;
   padding: 10px;
   border: 1px solid #ccc;
-  border-radius: 5px;
+  border-radius: 5%;
   font-size: 1.5rem;
 }
 label {
@@ -325,4 +325,10 @@ label {
   justify-content: center;
   align-items: center;
   flex-direction: column;
+}
+.map-switch{
+  display: flex;
+  justify-content: center;
+  gap: 20rem;
+  margin-top: 0.6rem;
 }

--- a/Muzik/src/components/MapSwitch.jsx
+++ b/Muzik/src/components/MapSwitch.jsx
@@ -1,0 +1,44 @@
+import { useLocation } from "react-router-dom";
+import { MODE } from "../utils/constants";
+import MapPage from "../containers/Map";
+import useMapSwitch from "../hooks/useMapSwitch";
+export default function MapSwitch({ userLat, userLng, onSave, favorites }) {
+  const location = useLocation();
+  const { currMode, handleClick } = useMapSwitch();
+  function renderMap(mode) {
+    if (mode === MODE.LIVE) {
+      return (
+        <MapPage
+          userLat={userLat}
+          userLng={userLng}
+          onSave={onSave}
+          favorites={favorites}
+        />
+      );
+    } else {
+      return <div> TEST MAP</div>;
+    }
+  }
+  return (
+    <>
+      <div className="map-switch">
+        <button
+          onClick={() => {
+            handleClick(MODE.LIVE);
+          }}
+        >
+          {MODE.LIVE}
+        </button>
+        <h3>Welcome {location.state.username}</h3>
+        <button
+          onClick={() => {
+            handleClick(MODE.EXPLORE);
+          }}
+        >
+          {MODE.EXPLORE}
+        </button>
+      </div>
+      {renderMap(currMode)}
+    </>
+  );
+}

--- a/Muzik/src/containers/ContentContainer.jsx
+++ b/Muzik/src/containers/ContentContainer.jsx
@@ -1,8 +1,8 @@
 import SongsContainer from "./SongsContainer";
-import MapPage from "./Map";
 import Admin from "../pages/Admin";
 import { getUserFavorites, saveSong } from "../api";
 import { useState, useEffect } from "react";
+import MapSwitch from "../components/MapSwitch";
 export default function ContentContainer({ currentSection, userLat, userLng }) {
   const [favorites, setFavorites] = useState([]);
   useEffect(() => {
@@ -15,7 +15,7 @@ export default function ContentContainer({ currentSection, userLat, userLng }) {
       lng,
       song.title,
       song.artist,
-      song.coverUrl,
+      song.coverUrl
     ).then((data) => {
       if (data.ok) {
         setFavorites(data.results);
@@ -33,7 +33,7 @@ export default function ContentContainer({ currentSection, userLat, userLng }) {
         />
       )}
       {currentSection === "map" && (
-        <MapPage
+        <MapSwitch
           userLat={userLat}
           userLng={userLng}
           onSave={handleAddToFavorite}

--- a/Muzik/src/containers/Map.jsx
+++ b/Muzik/src/containers/Map.jsx
@@ -1,4 +1,3 @@
-import { useLocation } from "react-router-dom";
 import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
 import useFetchClusters from "../hooks/useFetchClusters";
 import useDebounce from "../hooks/useDebounce";
@@ -47,7 +46,6 @@ function ClusteredMap({ clusters, onClusterClick }) {
   ));
 }
 export default function MapPage({ userLat, userLng, onSave, favorites }) {
-  const location = useLocation();
   const [isLoaded, setIsLoaded] = useState(false);
   const {
     handleMapIdle,
@@ -62,7 +60,6 @@ export default function MapPage({ userLat, userLng, onSave, favorites }) {
   const debouncedMapIdle = useDebounce(handleMapIdle, 400);
   return (
     <>
-      <h3>Welcome {location.state.username}</h3>
       <APIProvider
         apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
         onLoad={() => {
@@ -71,7 +68,7 @@ export default function MapPage({ userLat, userLng, onSave, favorites }) {
         }}
       >
         {isLoaded ? (
-          <div style={{ height: "75vh", width: "100%" }}>
+          <div style={{ height: "83vh", width: "100%" }}>
             <Map
               defaultZoom={2}
               minZoom={2}

--- a/Muzik/src/hooks/useMapSwitch.jsx
+++ b/Muzik/src/hooks/useMapSwitch.jsx
@@ -1,0 +1,12 @@
+import { useState, useCallback } from "react";
+import { MODE } from "../utils/constants";
+export default function useMapSwitch() {
+  const [currMode, setCurrMode] = useState(MODE.LIVE);
+  const handleClick = useCallback(
+    (mode) => {
+      setCurrMode(mode);
+    },
+    [setCurrMode]
+  );
+  return { handleClick, currMode };
+}

--- a/Muzik/src/utils/constants.js
+++ b/Muzik/src/utils/constants.js
@@ -1,0 +1,4 @@
+export const MODE = {
+  EXPLORE: "Explore mode 🌎",
+  LIVE: "Live mode 🎵"
+};


### PR DESCRIPTION
DESCRIPTION: Added two buttons that allow users switch between live/cluster mode and explore mode. Live mode displays clusters as well as cluster info while Explore mode does not have clusters present allowing users to click anywhere on the map and view trending songs possibly from the week before.

Milestone: [MVP FEATURE] Improve map interactivity allowing users toggle between two modes

TEST PLAN: By default, user navigates to live mode map. Toggle on mode buttons updates mode state.

https://www.loom.com/share/694a4ab25ff44c719de5e54d9c6fc738?sid=d6172b1a-c913-4134-96a5-716acda2a808

