### PR TITLE
[Tech Challenge 1] Protect Admin-related content with browser route guard

### DIFF
--- a/Muzik/src/App.jsx
+++ b/Muzik/src/App.jsx
@@ -8,6 +8,7 @@ import ProtectedRoute from "./auth/Protect";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import AdminContent from "./containers/AdminContent";
+import AdminProtectedRoute from "./auth/AdminProtect";
 function App() {
   return (
     <AuthProvider>
@@ -17,7 +18,9 @@ function App() {
           <Route path="/auth/login" element={<Login />} />
           <Route element={<ProtectedRoute />}>
             <Route path="/home" element={<Home />}></Route>
-            <Route path="/admin/dashboard" element={<AdminContent />}></Route>
+            <Route element={<AdminProtectedRoute />}>
+              <Route path="/admin/dashboard" element={<AdminContent />}></Route>
+            </Route>
           </Route>
         </Routes>
       </BrowserRouter>

--- a/Muzik/src/auth/AdminProtect.jsx
+++ b/Muzik/src/auth/AdminProtect.jsx
@@ -1,0 +1,6 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "./AuthContext";
+export default function AdminProtectedRoute() {
+  const { adminStatus } = useAuth();
+  return <>{adminStatus ? <Outlet /> : <Navigate to={"/home"} replace />}</>;
+}

--- a/Muzik/src/auth/AuthContext.jsx
+++ b/Muzik/src/auth/AuthContext.jsx
@@ -1,8 +1,11 @@
-import { createContext, useContext, useState } from "react";
-import { getToken } from "../api";
+import { createContext, useContext, useState, useEffect } from "react";
+import { getToken, isAdmin } from "../api";
+import { Spinner } from "react-spinner-toolkit";
 const AuthContext = createContext();
 export function AuthProvider({ children }) {
   const [token, setToken] = useState(() => getToken());
+  const [adminStatus, setAdminStatus] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   function login(newToken) {
     localStorage.setItem("token", newToken);
     setToken(newToken);
@@ -12,8 +15,44 @@ export function AuthProvider({ children }) {
     setToken(null);
   }
   const isAuthenticated = !!token;
+  async function checkAdmin() {
+    try {
+      const result = await isAdmin();
+      return result;
+    } catch (error) {
+      return false;
+    }
+  }
+  useEffect(() => {
+    async function verifyAdmin() {
+      if (isAuthenticated) {
+        const result = await checkAdmin();
+        setAdminStatus(result);
+      } else {
+        setAdminStatus(false);
+      }
+      setIsLoaded(true);
+    }
+    verifyAdmin();
+  }, [isAuthenticated]);
+  if (!isLoaded) {
+    return (
+      <div className="loading-container">
+        <Spinner
+          shape="threeDots"
+          color="#888"
+          loading
+          speed={1}
+          size={300}
+          transition={true}
+        />
+      </div>
+    );
+  }
   return (
-    <AuthContext.Provider value={{ login, logout, isAuthenticated, token }}>
+    <AuthContext.Provider
+      value={{ login, logout, isAuthenticated, token, adminStatus }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
Description: Created AdminProtectedRoute component to wrap admin content. Built off useAuth() to check if the current user has admin access

Milestone: [Tech Challenge 1] Integrate admin-related backend routes/logic into frontend

Test Plan: Verified that non-admin users are redirected to "/home" when trying to access "/admin/dashboard". Also confirmed that admin users can access admin content normally.