### PR TITLE
[Tech Challenge 1]Refactor access control matrix/ scope

### DIFF
--- a/Backend/routes/adminRoutes.js
+++ b/Backend/routes/adminRoutes.js
@@ -83,15 +83,13 @@ router.put(
   async (req, res) => {
     const { userId } = req.params;
     const reqRole = req.user.role;
-    const reqRegion = req.user.region;
     const { newRole } = req.body;
     const userRole = await getUserRole(userId);
-    const userRegion = await getUserRegion(userId);
     try {
       if (userRole === newRole) {
         return res.status(403).json(badReq(`User is already ${newRole}`));
       }
-      if (!canPromote(reqRole, userRole, reqRegion, userRegion, newRole)) {
+      if (!canPromote(reqRole, userRole, newRole)) {
         return res
           .status(403)
           .json(badReq("You are not allowed to promote this user"));

--- a/Backend/utils/AdminHelper.js
+++ b/Backend/utils/AdminHelper.js
@@ -1,5 +1,5 @@
 import { Role } from "../generated/prisma/index.js";
-export function canPromote(reqRole, userRole, reqRegion, userRegion, newRole) {
+export function canPromote(reqRole, userRole, newRole) {
   const globalToRegion =
     reqRole === Role.admin &&
     userRole === Role.user &&
@@ -7,22 +7,8 @@ export function canPromote(reqRole, userRole, reqRegion, userRegion, newRole) {
 
   if (globalToRegion) return true;
   //bool true represents whether global admin can promote user to region admin
-  const regionToRegion =
-    reqRole === Role.regionAdmin &&
-    userRole === Role.user &&
-    newRole === Role.regionAdmin &&
-    reqRegion === userRegion;
-
-  if (regionToRegion) {
-    return true;
-    // bool true represents whether region admin can promote user to region admin WITHIN the same region
-  }
-
   return false;
 }
 export function canDemote(reqRole, userRole) {
-  if (reqRole === Role.admin) {
-    return userRole !== Role.admin;
-  }
-  return false;
+  return reqRole === Role.admin && userRole !== Role.admin;
 }

--- a/Muzik/src/AdminSections.js
+++ b/Muzik/src/AdminSections.js
@@ -12,7 +12,6 @@ export const ROLE = {
 export const PERMISSIONS = {
   promote: {
     [ROLE.globalAdmin]: [ROLE.user],
-    [ROLE.regionAdmin]: [ROLE.user],
   },
   demote: {
     [ROLE.globalAdmin]: [ROLE.regionAdmin],


### PR DESCRIPTION
Description: Revoked promote action from regionAdmin to stabilize role hierarchy. Global admins still can't promote other users to global admin in case extra roles are added in the future.

Test Plan: https://www.loom.com/share/77da0760f42342c38671bbbe700a6698?sid=a9d2ab27-d24f-459b-a0ea-f34b9b1c6b78